### PR TITLE
build fix, maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<junit.version>4.12</junit.version>
 		<hamcrest.version>1.3</hamcrest.version>
+		<multiaddr.version>1.0.0</multiaddr.version>
+		<multibase.version>1.0.0</multibase.version>
+		<multihash.version>1.1.0</multihash.version>
 	</properties>
 
 	<dependencies>
@@ -48,6 +51,21 @@
 			<artifactId>hamcrest-core</artifactId>
 			<version>${hamcrest.version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.ipfs</groupId>
+			<artifactId>multiaddr</artifactId>
+			<version>${multiaddr.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.ipfs</groupId>
+			<artifactId>multibase</artifactId>
+			<version>${multibase.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.ipfs</groupId>
+			<artifactId>multihash</artifactId>
+			<version>${multihash.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/io/ipfs/cid/Cid.java
+++ b/src/main/java/io/ipfs/cid/Cid.java
@@ -50,7 +50,7 @@ public class Cid extends Multihash {
     public final Codec codec;
 
     public Cid(long version, Codec codec, Multihash hash) {
-        super(hash);
+        super(hash.toBytes());
         this.version = version;
         this.codec = codec;
     }


### PR DESCRIPTION
I have added maven dependencies to pom.xml.
After doing an 'mvn install' in each of java-multiaddr, java-multibase and java-multihash, this compiles.

I will shortly submit a pull request to java-ipfs as an exmaple where git submodules and the pom does it all.

I recommend to upload the artifacts to ossrh (a certified maven central repository), and delete the lib directory.
http://central.sonatype.org/pages/ossrh-guide.html