### PR TITLE
fix Maven dependencies and bump version to 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ for Maven, you can add the follwing sections to your POM.XML:
     <dependency>
       <groupId>com.github.ipld</groupId>
       <artifactId>java-cid</artifactId>
-      <version>v1.0.0</version>
+      <version>v1.0.1</version>
     </dependency>
   </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>io.ipfs</groupId>
 	<artifactId>cid</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>cid</name>
@@ -36,6 +36,13 @@
 		<hamcrest.version>1.3</hamcrest.version>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -48,6 +55,16 @@
 			<artifactId>hamcrest-core</artifactId>
 			<version>${hamcrest.version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.multiformats</groupId>
+			<artifactId>java-multibase</artifactId>
+			<version>v1.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.multiformats</groupId>
+			<artifactId>java-multihash</artifactId>
+			<version>v1.1.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
This will allow Maven users to include java-cid in their projects.

**After merge a new release `v1.0.1` must be tagged.**