### PR TITLE
Update Cid.java

### DIFF
--- a/src/main/java/io/ipfs/cid/Cid.java
+++ b/src/main/java/io/ipfs/cid/Cid.java
@@ -19,6 +19,7 @@ public class Cid extends Multihash {
         Raw(0x55),
         DagProtobuf(0x70),
         DagCbor(0x71),
+        Libp2pKey(0x72), // support for IPNS key (go-ipfs 0.8.0)
         EthereumBlock(0x90),
         EthereumTx(0x91),
         BitcoinBlock(0xb0),

--- a/src/main/java/io/ipfs/cid/Cid.java
+++ b/src/main/java/io/ipfs/cid/Cid.java
@@ -19,7 +19,7 @@ public class Cid extends Multihash {
         Raw(0x55),
         DagProtobuf(0x70),
         DagCbor(0x71),
-        Libp2pKey(0x72), // support for IPNS key (go-ipfs 0.8.0)
+        Libp2pKey(0x72),
         EthereumBlock(0x90),
         EthereumTx(0x91),
         BitcoinBlock(0xb0),


### PR DESCRIPTION
Added support for Libp2p-key (codec code 0x72) decoding of IPNS key (tested on go-ipfs version 0.8.0).