### PR TITLE
Migrate JUnit4 -> JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.junit>4.13.2</version.junit>
+        <version.junit>5.11.0</version.junit>
         <version.hamcrest>2.2</version.hamcrest>
         <version.multihash>v1.3.4</version.multihash>
 	</properties>
@@ -51,8 +51,8 @@
             <version>${version.multihash}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
@@ -78,7 +78,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>3.1.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/io/ipfs/cid/CidTest.java
+++ b/src/test/java/io/ipfs/cid/CidTest.java
@@ -1,17 +1,19 @@
 package io.ipfs.cid;
 
 import io.ipfs.multihash.*;
-import org.junit.*;
+import org.junit.jupiter.api.Test;
 import io.ipfs.multibase.*;
 
 import java.io.*;
 import java.security.*;
 import java.util.*;
 
-public class CidTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CidTest {
 
     @Test
-    public void validStrings() {
+    void validStrings() {
         List<String> examples = Arrays.asList(
                 "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB",
                 "QmatmE9msSfkKxoffpHwNLNKgwZG8eT9Bud6YoPab52vpy",
@@ -26,7 +28,7 @@ public class CidTest {
     }
 
     @Test
-    public void emptyStringShouldFail() throws IOException {
+    void emptyStringShouldFail() throws IOException {
         try {
             Cid cid = Cid.decode("");
             throw new RuntimeException();
@@ -34,7 +36,7 @@ public class CidTest {
     }
 
     @Test
-    public void basicMarshalling() throws Exception {
+    void basicMarshalling() throws Exception {
         MessageDigest hasher = MessageDigest.getInstance("SHA-512");
         byte[] hash = hasher.digest("TEST".getBytes());
 
@@ -42,24 +44,24 @@ public class CidTest {
         byte[] data = cid.toBytes();
 
         Cid cast = Cid.cast(data);
-        Assert.assertTrue("Invertible serialization", cast.equals(cid));
+        assertEquals(cast, cid, "Invertible serialization");
 
         Cid fromString = Cid.decode(cid.toString());
-        Assert.assertTrue("Invertible toString", fromString.equals(cid));
+        assertEquals(fromString, cid, "Invertible toString");
     }
 
     @Test
-    public void version0Handling() throws Exception {
+    void version0Handling() throws Exception {
         String hashString = "QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB";
         Cid cid = Cid.decode(hashString);
 
-        Assert.assertTrue("version 0", cid.version == 0);
+        assertEquals(0, cid.version, "version 0");
 
-        Assert.assertTrue("Correct hash", cid.toString().equals(hashString));
+        assertEquals(cid.toString(), hashString, "Correct hash");
     }
 
     @Test
-    public void version0Error() throws Exception {
+    void version0Error() throws Exception {
         String invalidString = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII";
         try {
             Cid cid = Cid.decode(invalidString);
@@ -68,10 +70,10 @@ public class CidTest {
     }
 
     @Test
-    public void lookByOfficialIPLDName() {
+    void lookByOfficialIPLDName() {
         Cid.Codec raw = Cid.Codec.lookupIPLDName("raw");
-        Assert.assertTrue("Raw Codec", raw.name().equals("Raw"));
+        assertEquals("Raw", raw.name(), "Raw Codec");
         Cid.Codec dagcbor = Cid.Codec.lookupIPLDName("dag-cbor");
-        Assert.assertTrue("DagCbor Codec", dagcbor.name().equals("DagCbor"));
+        assertEquals("DagCbor", dagcbor.name(), "DagCbor Codec");
     }
 }


### PR DESCRIPTION
The JUnit5 framework is the successor to JUnit4, and is currently maintained version.
Changes in this PR:
- Tests migrated from JUnit4 to JUnit5 using OpenRewrite
- Dependencies updated