### PR TITLE
Fix version in Maven POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.github.ipld</groupId>
 	<artifactId>java-cid</artifactId>
-	<version>v1.3.7</version>
+	<version>1.3.9-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>cid</name>


### PR DESCRIPTION
Given that there is a 1.3.8 on https://github.com/ipld/java-cid/releases already, I guess the current master branch is now 1.3.9-SNAPSHOT.

Also drop the v* prefix, that's unusual, and could confuse Maven.

@ianopolous merge?