### PR TITLE
Fix broken build by adding missing import java.io.UncheckedIOException

### DIFF
--- a/src/main/java/io/ipfs/cid/Cid.java
+++ b/src/main/java/io/ipfs/cid/Cid.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;


### PR DESCRIPTION
@ianopolous oups I broke this in #37 - sorry!

PS: In an ideal world, we should CI on this project, but it's probably "not worth it" to maintain that.