### PR TITLE
Use <version.multihash>1.3.5 instead of v1.3.4 in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <version.junit>5.11.0</version.junit>
         <version.hamcrest>2.2</version.hamcrest>
-        <version.multihash>v1.3.4</version.multihash>
+        <version.multihash>1.3.5</version.multihash>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
Related to https://github.com/enola-dev/enola/issues/1040.

See https://github.com/multiformats/java-multihash/pull/48 for https://github.com/multiformats/java-multihash/issues/47.

@ianopolous merge this after that?